### PR TITLE
Scaffold GlassHouse MVP with API, worker, and portal

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "GlassHouse",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22"
+    }
+  },
+  "forwardPorts": [3000,8000,5432],
+  "postCreateCommand": "pip install -r services/reason/requirements.txt && cd apps/portal && npm install",
+  "postStartCommand": "docker compose up -d"
+}

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+OPENAI_API_KEY=
+MODEL_PRIMARY=mock-primary
+MODEL_SECONDARY=mock-secondary
+NEXT_PUBLIC_REASON_API=http://localhost:8000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker compose build
+      - run: docker compose up -d db reason
+      - run: |
+          sleep 10
+          curl -f http://localhost:8000/health

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Node
+node_modules
+.next
+.env
+.env.local
+
+# Python
+__pycache__
+*.pyc
+
+# Docker
+**/data
+
+# others
+.DS_Store

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,8 @@
+tasks:
+  - init: docker compose build
+    command: docker compose up -d
+ports:
+  - port: 3000
+    onOpen: open-browser
+  - port: 8000
+    onOpen: open-browser

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.RECIPEPREFIX := >
+.PHONY: init up down logs dbshell
+
+init:
+>docker compose build
+
+up:
+>docker compose up -d
+
+down:
+>docker compose down
+
+logs:
+>docker compose logs -f
+
+dbshell:
+>docker compose exec db psql -U postgres glasshouse

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# GlassHouse
+
+Transparent, show-your-work AI governance stack.
+
+## Quickstart
+
+### Codespaces
+Open in GitHub Codespaces. Devcontainer will install deps and run `docker compose up` automatically.
+
+### Local
+```bash
+cp .env.example .env
+make init
+make up
+```
+Portal at http://localhost:3000 and API at http://localhost:8000.
+
+## Principles
+- Transparency by default: every answer has a trace and citations.
+- Dual-model rule.
+- Append-only ledger with Merkle roots.
+
+## Next Steps
+- Real model integrations
+- On-chain anchoring
+- Policy engine

--- a/apps/portal/Dockerfile
+++ b/apps/portal/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:22
+WORKDIR /app
+COPY package.json package.json
+RUN npm install
+COPY . .
+RUN npm run build
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/apps/portal/app/page.tsx
+++ b/apps/portal/app/page.tsx
@@ -1,0 +1,42 @@
+'use client'
+import { useState } from 'react'
+
+export default function Home() {
+  const [question, setQuestion] = useState('')
+  const [answer, setAnswer] = useState('')
+  const [traceId, setTraceId] = useState<number | null>(null)
+  const [citations, setCitations] = useState<string[]>([])
+
+  const ask = async () => {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_REASON_API}/ask`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ question })
+    })
+    const data = await res.json()
+    setAnswer(data.answer)
+    setCitations(data.citations)
+    setTraceId(data.trace_id)
+  }
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>GlassHouse</h1>
+      <textarea value={question} onChange={e => setQuestion(e.target.value)} />
+      <br />
+      <button onClick={ask}>Ask</button>
+      {answer && (
+        <div>
+          <h2>Answer</h2>
+          <p>{answer}</p>
+          <ul>
+            {citations.map(c => (
+              <li key={c}>{c}</li>
+            ))}
+          </ul>
+          {traceId && <a href={`/trace/${traceId}`}>View Trace</a>}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/portal/app/trace/[id]/page.tsx
+++ b/apps/portal/app/trace/[id]/page.tsx
@@ -1,0 +1,14 @@
+interface Props {
+  params: { id: string }
+}
+
+export default async function TracePage({ params }: Props) {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_REASON_API}/trace/${params.id}`, { cache: 'no-store' })
+  const data = await res.json()
+  return (
+    <div style={{ padding: 20 }}>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+      <a href="/">Back</a>
+    </div>
+  )
+}

--- a/apps/portal/next-env.d.ts
+++ b/apps/portal/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "portal",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/apps/portal/tsconfig.json
+++ b/apps/portal/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: glasshouse
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+
+  reason:
+    build: ./services/reason
+    environment:
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/glasshouse
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+
+  anchoring:
+    build: ./services/anchoring
+    environment:
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/glasshouse
+    depends_on:
+      - db
+
+  portal:
+    build: ./apps/portal
+    environment:
+      NEXT_PUBLIC_REASON_API: http://localhost:8000
+    ports:
+      - "3000:3000"
+    depends_on:
+      - reason
+
+volumes:
+  db-data:

--- a/infra/db/migrations/0001_init.sql
+++ b/infra/db/migrations/0001_init.sql
@@ -1,0 +1,47 @@
+CREATE TABLE event (
+  id SERIAL PRIMARY KEY,
+  type TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  payload_json JSONB NOT NULL,
+  prev_hash TEXT,
+  hash TEXT NOT NULL,
+  merkle_leaf TEXT NOT NULL
+);
+
+CREATE TABLE model (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  vendor TEXT NOT NULL,
+  version TEXT NOT NULL,
+  eval_json JSONB,
+  card_url TEXT,
+  hash TEXT NOT NULL
+);
+
+CREATE TABLE prompt (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  version TEXT NOT NULL,
+  template TEXT NOT NULL,
+  hash TEXT NOT NULL
+);
+
+CREATE TABLE trace (
+  id SERIAL PRIMARY KEY,
+  event_id INTEGER REFERENCES event(id),
+  model_id INTEGER REFERENCES model(id),
+  prompt_id INTEGER REFERENCES prompt(id),
+  tool_calls_json JSONB,
+  citations_json JSONB,
+  constitutional_checks_json JSONB,
+  signature TEXT
+);
+
+CREATE TABLE redaction (
+  id SERIAL PRIMARY KEY,
+  event_id INTEGER REFERENCES event(id),
+  scope TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  expires_at TIMESTAMPTZ,
+  canary_counter INTEGER DEFAULT 0
+);

--- a/services/anchoring/Dockerfile
+++ b/services/anchoring/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY worker.py worker.py
+CMD ["python", "worker.py"]

--- a/services/anchoring/requirements.txt
+++ b/services/anchoring/requirements.txt
@@ -1,0 +1,2 @@
+SQLAlchemy[asyncio]
+asyncpg

--- a/services/anchoring/worker.py
+++ b/services/anchoring/worker.py
@@ -1,0 +1,27 @@
+import asyncio
+import hashlib
+import os
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy import text
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+engine = create_async_engine(DATABASE_URL, echo=False)
+
+async def compute_root():
+    async with engine.connect() as conn:
+        res = await conn.execute(text("SELECT hash FROM event ORDER BY id DESC LIMIT 100"))
+        hashes = [row[0] for row in res]
+    if not hashes:
+        return None
+    concat = ''.join(sorted(hashes)).encode()
+    return hashlib.sha256(concat).hexdigest()
+
+async def main():
+    while True:
+        root = await compute_root()
+        if root:
+            print("Computed Merkle root", root)
+        await asyncio.sleep(3600)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/services/reason/Dockerfile
+++ b/services/reason/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app app
+CMD ["uvicorn", "app.server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/reason/app/contracts.py
+++ b/services/reason/app/contracts.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel
+from typing import Optional, List, Any
+
+class AskIn(BaseModel):
+    question: str
+    audience: Optional[str] = None
+    location: Optional[str] = None
+
+class AskOut(BaseModel):
+    answer: str
+    citations: List[str]
+    trace_id: int
+    models_used: List[str]
+    dissent: List[str] = []
+
+class TraceOut(BaseModel):
+    event: Any
+    trace: Any
+
+class LedgerEvent(BaseModel):
+    id: int
+    type: str
+    created_at: str
+    hash: str

--- a/services/reason/app/crypto.py
+++ b/services/reason/app/crypto.py
@@ -1,0 +1,8 @@
+import hashlib
+import orjson
+
+
+def sha256(payload) -> str:
+    if not isinstance(payload, (bytes, bytearray)):
+        payload = orjson.dumps(payload)
+    return hashlib.sha256(payload).hexdigest()

--- a/services/reason/app/db.py
+++ b/services/reason/app/db.py
@@ -1,0 +1,13 @@
+import os
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlalchemy import MetaData
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+engine = create_async_engine(DATABASE_URL, echo=False)
+metadata = MetaData()
+SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+async def init_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(metadata.create_all)

--- a/services/reason/app/models.py
+++ b/services/reason/app/models.py
@@ -1,0 +1,60 @@
+from sqlalchemy import Table, Column, Integer, Text, DateTime, JSON, ForeignKey, func
+from .db import metadata
+
+Event = Table(
+    "event",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("type", Text, nullable=False),
+    Column("created_at", DateTime(timezone=True), server_default=func.now()),
+    Column("payload_json", JSON, nullable=False),
+    Column("prev_hash", Text),
+    Column("hash", Text, nullable=False),
+    Column("merkle_leaf", Text, nullable=False),
+)
+
+Model = Table(
+    "model",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("name", Text, nullable=False),
+    Column("vendor", Text, nullable=False),
+    Column("version", Text, nullable=False),
+    Column("eval_json", JSON),
+    Column("card_url", Text),
+    Column("hash", Text, nullable=False),
+)
+
+Prompt = Table(
+    "prompt",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("name", Text, nullable=False),
+    Column("version", Text, nullable=False),
+    Column("template", Text, nullable=False),
+    Column("hash", Text, nullable=False),
+)
+
+Trace = Table(
+    "trace",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("event_id", ForeignKey("event.id")),
+    Column("model_id", ForeignKey("model.id")),
+    Column("prompt_id", ForeignKey("prompt.id")),
+    Column("tool_calls_json", JSON),
+    Column("citations_json", JSON),
+    Column("constitutional_checks_json", JSON),
+    Column("signature", Text),
+)
+
+Redaction = Table(
+    "redaction",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("event_id", ForeignKey("event.id")),
+    Column("scope", Text, nullable=False),
+    Column("reason", Text, nullable=False),
+    Column("expires_at", DateTime(timezone=True)),
+    Column("canary_counter", Integer, server_default="0"),
+)

--- a/services/reason/app/providers.py
+++ b/services/reason/app/providers.py
@@ -1,0 +1,15 @@
+from typing import List, Dict
+
+async def get_answers(question: str) -> List[Dict]:
+    return [
+        {
+            "model": "mock-primary",
+            "text": f"Primary answer to '{question}'",
+            "citations": ["https://example.com/primary"]
+        },
+        {
+            "model": "mock-secondary",
+            "text": f"Secondary answer to '{question}'",
+            "citations": ["https://example.com/secondary"]
+        }
+    ]

--- a/services/reason/app/routes/ask.py
+++ b/services/reason/app/routes/ask.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy import insert
+from ..db import SessionLocal
+from ..models import Event, Trace
+from ..contracts import AskIn, AskOut
+from .. import providers, crypto
+
+router = APIRouter()
+
+async def get_session():
+    async with SessionLocal() as session:
+        yield session
+
+@router.post("/ask", response_model=AskOut)
+async def ask(data: AskIn, session=Depends(get_session)):
+    answers = await providers.get_answers(data.question)
+    event_payload = {"question": data.question, "answers": answers}
+    h = crypto.sha256(event_payload)
+    res = await session.execute(
+        insert(Event).values(type="ask.answer", payload_json=event_payload, hash=h, merkle_leaf=h).returning(Event.c.id)
+    )
+    event_id = res.scalar_one()
+    res = await session.execute(
+        insert(Trace).values(event_id=event_id, citations_json=answers[0]["citations"]).returning(Trace.c.id)
+    )
+    trace_id = res.scalar_one()
+    await session.commit()
+    return AskOut(
+        answer=answers[0]["text"],
+        citations=answers[0]["citations"],
+        trace_id=trace_id,
+        models_used=[a["model"] for a in answers],
+        dissent=[answers[1]["text"]]
+    )

--- a/services/reason/app/routes/health.py
+++ b/services/reason/app/routes/health.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/health")
+async def health():
+    return {"ok": True}

--- a/services/reason/app/routes/ledger.py
+++ b/services/reason/app/routes/ledger.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from ..db import SessionLocal
+from ..models import Event
+from ..contracts import LedgerEvent
+
+router = APIRouter()
+
+async def get_session():
+    async with SessionLocal() as session:
+        yield session
+
+@router.get("/ledger", response_model=list[LedgerEvent])
+async def ledger(session=Depends(get_session)):
+    res = await session.execute(
+        select(Event.c.id, Event.c.type, Event.c.created_at, Event.c.hash).order_by(Event.c.created_at.desc()).limit(50)
+    )
+    rows = res.all()
+    return [
+        LedgerEvent(id=r.id, type=r.type, created_at=r.created_at.isoformat(), hash=r.hash)
+        for r in rows
+    ]

--- a/services/reason/app/routes/trace.py
+++ b/services/reason/app/routes/trace.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from ..db import SessionLocal
+from ..models import Event, Trace
+from ..contracts import TraceOut
+
+router = APIRouter()
+
+async def get_session():
+    async with SessionLocal() as session:
+        yield session
+
+@router.get("/trace/{trace_id}", response_model=TraceOut)
+async def get_trace(trace_id: int, session=Depends(get_session)):
+    res = await session.execute(
+        select(Trace, Event).join(Event, Trace.c.event_id == Event.c.id).where(Trace.c.id == trace_id)
+    )
+    row = res.mappings().first()
+    if not row:
+        raise HTTPException(status_code=404, detail="not found")
+    return TraceOut(event=row["Event"], trace=row["Trace"])

--- a/services/reason/app/server.py
+++ b/services/reason/app/server.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI
+from .routes import health, ask, trace, ledger
+from .db import init_db
+
+app = FastAPI(title="GlassHouse Reason")
+app.include_router(health.router)
+app.include_router(ask.router)
+app.include_router(trace.router)
+app.include_router(ledger.router)
+
+@app.on_event("startup")
+async def startup():
+    await init_db()

--- a/services/reason/requirements.txt
+++ b/services/reason/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn[standard]
+SQLAlchemy[asyncio]
+asyncpg
+cryptography
+orjson
+httpx


### PR DESCRIPTION
## Summary
- add docker-compose for db, FastAPI reason service, anchoring worker, and Next.js portal
- implement initial schema, dual-model ask endpoint, ledger, trace lookup, and anchoring worker
- scaffold portal to submit questions and view traces; include devcontainer, Gitpod, CI, Makefile

## Testing
- `docker compose up --build -d` *(fails: command not found)*
- `pip install -r services/reason/requirements.txt` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bad1aa3dc0832093e0b3664b50e1c1