### PR TITLE
chore: use base image for docker feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,13 @@
 {
   "name": "GlassHouse",
-  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/node:1": {
       "version": "22"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.11"
     }
   },
   "forwardPorts": [3000,8000,5432],


### PR DESCRIPTION
## Summary
- use ubuntu-24.04 base image for devcontainer
- add python 3.11 feature and keep node 22 and docker-in-docker

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`
- `docker --version` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68bb529c8d0083209a694abeadb7e915